### PR TITLE
Update config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,6 +18,8 @@ enableRobotsTXT = true
 
 [params]
 
+  mainSections = ['blog']
+
   [params.logo]
     main = "img/logo/logo.svg"
     alt = "Tella Logo"


### PR DESCRIPTION
This will fix a bug when number of products is higher than number of blog articles.
It is not a case for this state of webpage nevertheless could be easily achieved.
`mainSections` defaults to the section with the most pages.

Ps. thanks for a great hugo theme.