### PR TITLE
make blog section on homepage optional

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -18,6 +18,7 @@ enableRobotsTXT = true
 
 [params]
 
+  showBlog = true
   mainSections = ['blog']
 
   googleFonts = true

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,10 +22,12 @@
     </div>
     {{- partial "slide.html" . -}}
     {{- partial "strip.html" . -}}
+    {{ if ne .Site.Params.showBlog false }}
     <div class="mx-auto my-10 max-w-6xl">
         <h2 class="text-4xl ml-2">Blog</h2>
         {{- partial "recent.html" . -}}
     </div>
+    {{ end }}
     {{- partial "footer.html" . -}}
     <script src="{{ "/js/swiper-bundle.min.js" | relURL }}"></script>
     <script>


### PR DESCRIPTION
I want to use this pretty theme, but I don't have a blog. I added this option to the configuration so that I could hide the blog section on the homepage.

I've made sure that the new param is optional: if you don't define it in your `config.toml` file the blog section will still show.