### PR TITLE
make slider text color configurable

### DIFF
--- a/exampleSite/data/slide.json
+++ b/exampleSite/data/slide.json
@@ -5,6 +5,7 @@
   },
   {
     "title": "Sample text here...",
-    "image": "img/slide/slide02.jpg"
+    "image": "img/slide/slide02.jpg",
+    "color": "text-black"
   }
 ]

--- a/layouts/partials/slide.html
+++ b/layouts/partials/slide.html
@@ -4,7 +4,7 @@
         <div class="swiper-slide">
             <img src="{{ .image }}" alt="">
             <div class="s-fade-txt">
-                <h1 class="text-4xl text-white">{{ .title }}</h1>
+                <h1 class="text-4xl {{ or .color "text-white" }}">{{ .title }}</h1>
             </div>
         </div>
         {{ end }}


### PR DESCRIPTION
I have a mix of light and dark images in my slide. This option allows me to use one of the other colors defined in the tailwind css, or add my own custom class to do something different.

I included an example of it being used in the example Site, but I'm not sure how you feel about this. Of course it could be dropped if you like. Unfortunately there doesn't seem to be any documentation where I could mention how the setting works.