### PR TITLE
Use configured language

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="{{ or .Site.Language.Lang "ja" }}">
 
 <head>
   {{- partial "head.html" . -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,7 +4,7 @@
 <meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:locale" content="ja_JP" />
+<meta property="og:locale" content="{{ replace (or .Language.LanguageCode "ja_JP") "-" "_" }}" />
 <meta name="twitter:card" content="summary_large_image">
 <meta property="twitter:title" content="{{ .Title }}">
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 <meta property="og:title" content="{{ .Title }} | {{ .Site.Title }}" />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:locale" content="ja_JP" />
+<meta property="og:locale" content="{{ replace (or .Language.LanguageCode "ja_JP") "-" "_" }}" />
 <meta name="twitter:card" content="summary_large_image">
 <meta property="twitter:title" content="{{ .Title }}">
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,6 +9,7 @@
     <meta property="og:url" content="{{ .Site.Params.homepage_meta_tags.meta_og_url }}" />
     <meta property="og:image" content="{{ .Site.Params.homepage_meta_tags.meta_og_image }}" />
     <meta property="og:description" content="{{ .Site.Params.homepage_meta_tags.meta_og_description }}" />
+    <meta property="og:locale" content="{{ replace (or .Language.LanguageCode "ja_JP") "-" "_" }}" />
     <meta name="twitter:card" content="{{ .Site.Params.homepage_meta_tags.meta_twitter_card }}" />
     <meta name="twitter:site" content="{{ .Site.Params.homepage_meta_tags.meta_twitter_site }}" />
     <meta name="twitter:creator" content="{{ .Site.Params.homepage_meta_tags.meta_twitter_creator }}" />

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="{{ or .Site.Language.Lang "ja" }}">
 
 <head>
     {{- partial "head.html" . -}}

--- a/layouts/partials/seo/print.html
+++ b/layouts/partials/seo/print.html
@@ -56,7 +56,7 @@
 {{- end -}}
 
 {{/* 言語 */}}
-{{- $.Scratch.SetInMap "seo" "locale" "ja_JP" -}}
+{{- $.Scratch.SetInMap "seo" "locale" (replace (or .Language.LanguageCode "ja_JP") "-" "_") -}}
 
 {{/* Canonical */}}
 {{ with .Params.seo.canonical }}


### PR DESCRIPTION
I noticed this while looking through the header tags on my website. This change causes the template to use the values from the ` defaultContentLanguage` and `languageCode` settings in the site config file.

日本語はいい言葉ですが、私のウェブサイトで英語を作ります。