### PR TITLE
include `<meta name="description"...` on single and list pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,12 +19,15 @@
 {{ end }}
 
 {{- if .Description }}
+<meta name="description" content="{{ .Description }}" />
 <meta property="og:description" content="{{ .Description }}" />
 <meta property="twitter:description" content="{{ .Description }}" />
 {{- else if .Summary }}
+<meta name="description" content="{{ .Summary }}" />
 <meta property="og:description" content="{{ .Summary }}" />
 <meta property="twitter:description" content="{{ .Summary }}" />
 {{- else if .Site.Params.description }}
+<meta name="description" content="{{ .Site.Params.description }}" />
 <meta property="og:description" content="{{ .Site.Params.description }}" />
 <meta property="twitter:description" content="{{ .Site.Params.description }}" />
 {{- end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -19,12 +19,15 @@
 {{ end }}
 
 {{- if .Description }}
+<meta name="description" content="{{ .Description }}" />
 <meta property="og:description" content="{{ .Description }}" />
 <meta property="twitter:description" content="{{ .Description }}" />
 {{- else if .Summary }}
+<meta name="description" content="{{ .Summary }}" />
 <meta property="og:description" content="{{ .Summary }}" />
 <meta property="twitter:description" content="{{ .Summary }}" />
 {{- else if .Site.Params.description }}
+<meta name="description" content="{{ .Site.Params.description }}" />
 <meta property="og:description" content="{{ .Site.Params.description }}" />
 <meta property="twitter:description" content="{{ .Site.Params.description }}" />
 {{- end }}


### PR DESCRIPTION
I noticed that the `<meta name="description"...`  tag wasn't appearing on any pages except the homepage. This adds it to all the child pages as well.