### PR TITLE
remove unnecessary duplicate `<meta property="og:image:url"...`

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,11 +11,9 @@
 {{ if .Params.image }}
 {{ with .Params.image }}
 <meta property="og:image" content="{{ . | absURL }}">
-<meta property="og:image:url" content="{{ . | absURL }}">
 {{ end }}
 {{ else }}
 <meta property="og:image" content="{{ .Site.Params.homepage_meta_tags.meta_og_image | absURL }}">
-<meta property="og:image:url" content="{{ .Site.Params.homepage_meta_tags.meta_og_image | absURL }}">
 {{ end }}
 
 {{- if .Description }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,11 +11,9 @@
 {{ if .Params.image }}
 {{ with .Params.image }}
 <meta property="og:image" content="{{ . | absURL }}">
-<meta property="og:image:url" content="{{ . | absURL }}">
 {{ end }}
 {{ else }}
 <meta property="og:image" content="{{ .Site.Params.homepage_meta_tags.meta_og_image | absURL }}">
-<meta property="og:image:url" content="{{ .Site.Params.homepage_meta_tags.meta_og_image | absURL }}">
 {{ end }}
 
 {{- if .Description }}

--- a/layouts/partials/seo/print.html
+++ b/layouts/partials/seo/print.html
@@ -79,9 +79,7 @@
 {{ if .Params.image }}
     {{ with .Params.image }}
 <meta property="og:image" content="{{ . | absURL }}">
-<meta property="og:image:url" content="{{ . | absURL }}">
     {{ end }}
 {{ else }}
 <meta property="og:image" content="{{ .Site.Params.og_image | absURL }}">
-<meta property="og:image:url" content="{{ .Site.Params.og_image | absURL }}">
 {{ end }}


### PR DESCRIPTION
According to the [open graph documentation](https://ogp.me/#structured), `og:image:url` is a duplicate of `og:image`. This change removes the former on the single and list pages where it appears. 