### PR TITLE
Replace deprecated .Site.GoogleAnalytics

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,5 +1,5 @@
 {{ if not hugo.IsServer }}
-{{ with .Site.GoogleAnalytics }}
+{{ with .Site.Config.Services.GoogleAnalytics.ID }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
 <script>


### PR DESCRIPTION
At present, attempting to build results in the following error:

```
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.
```

Making the suggested change allows the hugo build to complete successfully.