### PR TITLE
Update deprecated `.Site.Social` usage

### DIFF
--- a/layouts/partials/seo/print.html
+++ b/layouts/partials/seo/print.html
@@ -42,7 +42,7 @@
 {{- $.Scratch.SetInMap "seo" "twitter_card" "summary_large_image" -}}
 
 {{/* We check the site config sports a Social.twitter and use as handle */}}
-{{- with .Site.Social.twitter -}}
+{{- with .Site.Params.Social.twitter -}}
 	{{- $.Scratch.SetInMap "seo" "twitter_handle" (printf "@%s" .) -}}
 {{- end -}}
 


### PR DESCRIPTION
`.Site.Social` was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.140.0. Updates usage with `.Site.Params.Social`.