### PR TITLE
fix error on `npm run start`

### DIFF
--- a/exampleSite/package.json
+++ b/exampleSite/package.json
@@ -13,6 +13,7 @@
     "build": "tailwindcss -i ./themes/tella/assets/css/main.css -o ./themes/tella/assets/css/style.css && hugo --minify"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.12",
     "@tailwindcss/typography": "^0.5.12",
     "autoprefixer": "^10.4.19",
     "concurrently": "^9.0.0",
@@ -21,3 +22,4 @@
     "tailwindcss": "^4.0.1"
   }
 }
+

--- a/exampleSite/postcss.config.js
+++ b/exampleSite/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
When you follow the readme instructions and get to `npm run start`,  upon running that command 
you would see:

ERROR POSTCSS: failed to transform "/css/style.css" (text/css): Error: It looks like you're trying to use tailwindcss directly as a PostCSS plugin. The PostCSS plugin has moved to a separate package, so to continue using Tailwind CSS with PostCSS you'll need to install @tailwindcss/postcss and update your PostCSS configuration.

This PR fixes that.